### PR TITLE
#48 - Use conversion_urls for carousel thumbnail

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2030,7 +2030,7 @@ __webpack_require__.r(__webpack_exports__);
   computed: {
     backgroundImage: function backgroundImage() {
       return function (item) {
-        return 'background-image: url("' + item.conversion_urls.thumb + '")';
+        return "background-image: url(" + item.conversion_urls[Object.keys(item.conversion_urls)[0]] + ")";
       };
     }
   }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=498f42cff03b73fb88ff",
+    "/app.js": "/app.js?id=403ebe4e3a2835976ed9",
     "/app.css": "/app.css?id=47e3d55039a6d1a3c720",
     "/images/icon-add.svg": "/images/icon-add.svg?id=f35ff7376a119c2d780b",
     "/images/icon-arrow-back.svg": "/images/icon-arrow-back.svg?id=963a92661eaa72c7bfd3",

--- a/resources/js/components/carousel/mm-carousel-card.vue
+++ b/resources/js/components/carousel/mm-carousel-card.vue
@@ -19,7 +19,7 @@ export default {
   },
   computed: {
     backgroundImage: () => (item) => {
-      return 'background-image: url("' + item.conversion_urls.thumb + '")';
+      return "background-image: url(" + item.conversion_urls[Object.keys(item.conversion_urls)[0]] + ")";
     },
   },
 };


### PR DESCRIPTION
Close #48 

# Fix : 

I use `conversion_urls` as background-image : 
`return "background-image: url(" + item.conversion_urls[Object.keys(item.conversion_urls)[0]] + ")";`

# Preview : 

<img width="1441" alt="Screen Shot 2021-08-17 at 10 48 37 AM" src="https://user-images.githubusercontent.com/4960853/129748320-4f80126b-20b3-46a8-9186-5bf485081c7d.png">
