### PR TITLE
#70 adding a custom event to the attach request that will link to log…

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -39165,7 +39165,16 @@ var actions = {
   },
   attatchMedia: function attatchMedia(context, value) {
     axios__WEBPACK_IMPORTED_MODULE_0___default.a.post("/media-api/attach", value).then(function (response) {
-      location.reload();
+      var myEvent = new CustomEvent("customEvent", {
+        detail: {
+          tag: value.tag,
+          data: response.data.data
+        },
+        bubbles: true,
+        cancelable: true,
+        composed: false
+      });
+      document.getElementsByClassName("media-picker-thumbs")[0].dispatchEvent(myEvent);
     })["catch"](function (e) {
       console.log(e, "error when attaching");
     });

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=e13fc23b3d27b53f78ea",
+    "/app.js": "/app.js?id=09ea4ac0eb85bf179dde",
     "/app.css": "/app.css?id=7651f2296c8407190b31",
     "/images/icon-add.svg": "/images/icon-add.svg?id=f35ff7376a119c2d780b",
     "/images/icon-arrow-back.svg": "/images/icon-arrow-back.svg?id=963a92661eaa72c7bfd3",

--- a/resources/js/store/actions.js
+++ b/resources/js/store/actions.js
@@ -364,7 +364,17 @@ export const actions = {
     axios
     .post("/media-api/attach", value)
     .then(response => {
-      location.reload()
+      const myEvent = new CustomEvent("customEvent", {
+        detail: {
+          tag: value.tag,
+          data: response.data.data
+        },
+        bubbles: true,
+        cancelable: true,
+        composed: false,
+      });
+      document.getElementsByClassName("media-picker-thumbs")[0].dispatchEvent(myEvent);
+
     }).catch(e => {
       console.log(e, "error when attaching")
     })


### PR DESCRIPTION
### Overview
we're changing our approach of how the media manager behaves when the the attach request is done.

### Work that was done
when we receive a response through the attach media request we fire a custom event with our attached data. the event listener lives in the project directory. and thats where the bulk of the work is taking place.

