### PR TITLE
#70 instead of closing the MM when we attach we show a success message

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2605,7 +2605,10 @@ __webpack_require__.r(__webpack_exports__);
       });
 
       if (imagesToAttach.media.length > 0) {
-        this.$store.dispatch("attatchMedia", imagesToAttach);
+        this.$store.dispatch("attatchMedia", {
+          imagesToAttach: imagesToAttach,
+          vm: this
+        });
       }
     }
   },
@@ -39164,10 +39167,10 @@ var actions = {
     context.commit("SET_LANG", value);
   },
   attatchMedia: function attatchMedia(context, value) {
-    axios__WEBPACK_IMPORTED_MODULE_0___default.a.post("/media-api/attach", value).then(function (response) {
+    axios__WEBPACK_IMPORTED_MODULE_0___default.a.post("/media-api/attach", value.imagesToAttach).then(function (response) {
       var attachEvent = new CustomEvent("mediaAttachEvent", {
         detail: {
-          tag: value.tag,
+          tag: value.imagesToAttach.tag,
           data: response.data.data
         },
         bubbles: true,
@@ -39175,6 +39178,11 @@ var actions = {
         composed: false
       });
       document.getElementsByClassName("attach-media-listener")[0].dispatchEvent(attachEvent);
+      value.vm.$toast.open({
+        type: "success",
+        position: "bottom-left",
+        message: value.vm.$i18n.t("actions.uploaded")
+      });
     })["catch"](function (e) {
       console.log(e, "error when attaching");
     });

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=b67e35691284d5a3cddf",
+    "/app.js": "/app.js?id=b2f06b57e7142e535ba3",
     "/app.css": "/app.css?id=7651f2296c8407190b31",
     "/images/icon-add.svg": "/images/icon-add.svg?id=f35ff7376a119c2d780b",
     "/images/icon-arrow-back.svg": "/images/icon-arrow-back.svg?id=963a92661eaa72c7bfd3",

--- a/resources/js/components/mm-attach-button.vue
+++ b/resources/js/components/mm-attach-button.vue
@@ -36,7 +36,7 @@ export default {
             });
 
             if (imagesToAttach.media.length > 0) {
-                this.$store.dispatch("attatchMedia", imagesToAttach)
+                this.$store.dispatch("attatchMedia", {imagesToAttach: imagesToAttach , vm: this})
             }
         }
     },

--- a/resources/js/store/actions.js
+++ b/resources/js/store/actions.js
@@ -362,11 +362,11 @@ export const actions = {
   },
   attatchMedia(context, value) {
     axios
-    .post("/media-api/attach", value)
+    .post("/media-api/attach", value.imagesToAttach)
     .then(response => {
       const attachEvent = new CustomEvent("mediaAttachEvent", {
         detail: {
-          tag: value.tag,
+          tag: value.imagesToAttach.tag,
           data: response.data.data
         },
         bubbles: true,
@@ -374,6 +374,12 @@ export const actions = {
         composed: false,
       });
       document.getElementsByClassName("attach-media-listener")[0].dispatchEvent(attachEvent);
+
+      value.vm.$toast.open({
+        type: "success",
+        position: "bottom-left",
+        message: value.vm.$i18n.t("actions.uploaded")
+      });
 
     }).catch(e => {
       console.log(e, "error when attaching")


### PR DESCRIPTION
adding a success message when we attach a a piece of media we do this because we're un able to successfully  close the MM modal without causing the page to act up