### PR TITLE
Handle duplicate file names on Upload

### DIFF
--- a/src/Http/Controllers/MediaController.php
+++ b/src/Http/Controllers/MediaController.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use Plank\Mediable\Exceptions\MediaMoveException;
+use Plank\MediaManager\Http\Requests\MediaStoreRequest;
 use Plank\MediaManager\Http\Requests\MediaUpdateRequest;
 use Plank\MediaManager\Models\Media;
 use Plank\Mediable\MediaUploader;
@@ -16,6 +17,8 @@ use Plank\MediaManager\MediaManager;
 class MediaController extends BaseController
 {
     protected $manager;
+
+    protected $model;
 
     protected $uploader;
 
@@ -28,6 +31,7 @@ class MediaController extends BaseController
     public function __construct(MediaUploader $uploader, array $ignore = [])
     {
         $this->manager = new MediaManager();
+        $this->model = config('media-manager.model');
         $this->uploader = $uploader;
         $this->ignore = array_merge($ignore, $this->ignore);
     }
@@ -40,8 +44,7 @@ class MediaController extends BaseController
      */
     public function show($id)
     {
-        $model = config('media-manager.model');
-        return response($model::findOrFail($id));
+        return response($this->model::findOrFail($id));
     }
 
     /**
@@ -100,32 +103,39 @@ class MediaController extends BaseController
      * @throws \Plank\Mediable\Exceptions\MediaUpload\FileSizeException
      * @throws \Plank\Mediable\Exceptions\MediaUpload\ForbiddenException
      */
-    public function create(Request $request)
+    public function create(MediaStoreRequest $request)
     {
+        // Set up data we need for uploads, turn file into an array so we can always iterate over it.
         $media = is_array($request->file) ? $request->file : [$request->file] ;
         $data = collect($request->only(['title', 'alt', 'caption', 'credit']));
         $disk = $this->manager->verifyDisk($request->disk);
         $path = $this->manager->verifyDirectory($disk, trim($request->path, "/"));
         $response = [];
-        foreach ($media as $index => $m) {
+
+
+        foreach ($media as $m) {
+
+            // Prep an uploader instance with the file.
             $model = $this->uploader
                 ->toDestination($disk, $path)
                 ->fromSource($m);
-                if ($data->isNotEmpty() &&
-                    (is_array($data['title']) || is_array($data['alt']) || is_array($data['caption']) || is_array($data['credit']))) {
-                    $model->beforeSave(function (Media $m) use ($data, $index) {
-                        $details = $data->mapWithKeys(function ($entries, $field) use ($index) {
-                            return [$field => $entries[$index] ?? null];
-                        });
-                        $m->fill($details->toArray());
-                    });
-                } elseif (count($media) == 1) {
-                    $model->beforeSave(function (Media $m) use ($data, $index) {
-                        $m->fill($data->toArray());
-                    });
-                }
+
+            // If the request has meta data about the file, apply that meta data as part of the upload.
+            if ($data->isNotEmpty()) {
+                $model->beforeSave(function (Media $m) use ($data) {
+                    $m->fill($data->toArray());
+                });
+            }
+
+            // Check that the file we're uploading doesn't already exist
+            if ($c = $this->model::inOrUnderDirectory($path)->where('filename', $m->getClientOriginalName())->count()) {
+                $model = $model->useFilename("{$m->getClientOriginalName()}_{$c}");
+            }
+
             $response[] = $model->upload();
         }
+
+        // Return all the media.
         return response($response);
     }
 

--- a/src/Http/Controllers/MediaController.php
+++ b/src/Http/Controllers/MediaController.php
@@ -128,7 +128,7 @@ class MediaController extends BaseController
             }
 
             // Check that the file we're uploading doesn't already exist
-            if ($c = $this->model::inOrUnderDirectory($path)->where('filename', $m->getClientOriginalName())->count()) {
+            if ($c = $this->model::inOrUnderDirectory($disk, $path)->where('filename', $m->getClientOriginalName())->count()) {
                 $model = $model->useFilename("{$m->getClientOriginalName()}_{$c}");
             }
 

--- a/src/Http/Controllers/MediaManagerController.php
+++ b/src/Http/Controllers/MediaManagerController.php
@@ -101,10 +101,13 @@ class MediaManagerController extends BaseController
     {
         $disk = $this->manager->verifyDisk($request->disk);
         $path = $this->manager->verifyDirectory($disk, $request->path);
-        $string = $request->path;
-        $string = substr($string, 0, strrpos($string, "/"));
+        $parent = collect(explode("/", $path))->slice(-1)->implode("/");
+
+        Cache::forget("root.{$parent}");
+        Cache::forget("root.{$path}");
         Storage::disk($disk)->deleteDirectory($path);
         Media::where('directory', $path)->delete();
-        return response(["success" => true, 'parentFolder' => $string]);
+
+        return response(["success" => true, 'parentFolder' => $parent]);
     }
 }

--- a/src/Http/Requests/MediaStoreRequest.php
+++ b/src/Http/Requests/MediaStoreRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Plank\MediaManager\Http\Requests;
+
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class MediaStoreRequest extends FormRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        $model = config('media-manager.model');
+        $table = (new $model())->getTable();
+
+        return [
+            'file' => ['required', 'file_array'],
+            'title' => ['sometimes', 'string'],
+            'alt' => ['sometimes', 'string'],
+            'caption' => ['sometimes', 'string'],
+            'credit' => ['sometimes', 'string'],
+        ];
+    }
+
+//    public function messages()
+//    {
+//        return [
+//            'title.required_without' => 'A title is required',
+//        ];
+//    }
+}

--- a/src/Http/Requests/MediaStoreRequest.php
+++ b/src/Http/Requests/MediaStoreRequest.php
@@ -5,6 +5,7 @@ namespace Plank\MediaManager\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Plank\MediaManager\Rules\FileArray;
 
 class MediaStoreRequest extends FormRequest
 {
@@ -19,7 +20,7 @@ class MediaStoreRequest extends FormRequest
         $table = (new $model())->getTable();
 
         return [
-            'file' => ['required', 'file_array'],
+            'file' => ['required', new FileArray()],
             'title' => ['sometimes', 'string'],
             'alt' => ['sometimes', 'string'],
             'caption' => ['sometimes', 'string'],

--- a/src/MediaManagerServiceProvider.php
+++ b/src/MediaManagerServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Plank\MediaManager;
 
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Illuminate\Support\Facades\Validator;
 use Plank\MediaManager\Commands\GenerateConversions;
 use Plank\MediaManager\Commands\InstallManager;
 use Illuminate\Contracts\Container\Container;
@@ -21,6 +23,17 @@ class MediaManagerServiceProvider extends ServiceProvider
             define('MANAGER_PATH', realpath(__DIR__.'/../'));
         }
 
+
+        Validator::extend('file_array', function ($attribute, $value, $parameters, $validator) {
+
+            $areFiles = false;
+            if (is_array($value)) {
+                foreach ($value as $item) {
+                    $areFiles = $areFiles && ($item instanceof UploadedFile && $item->isValid());
+                }
+            }
+            return ($value instanceof UploadedFile && $value->isValid()) || $areFiles;
+        });
 
         // $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'media-manager');
          $this->loadMigrationsFrom(MANAGER_PATH.'/database/migrations');

--- a/src/MediaManagerServiceProvider.php
+++ b/src/MediaManagerServiceProvider.php
@@ -2,8 +2,6 @@
 
 namespace Plank\MediaManager;
 
-use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Illuminate\Support\Facades\Validator;
 use Plank\MediaManager\Commands\GenerateConversions;
 use Plank\MediaManager\Commands\InstallManager;
 use Illuminate\Contracts\Container\Container;
@@ -22,18 +20,6 @@ class MediaManagerServiceProvider extends ServiceProvider
         if (!defined('MANAGER_PATH')) {
             define('MANAGER_PATH', realpath(__DIR__.'/../'));
         }
-
-
-        Validator::extend('file_array', function ($attribute, $value, $parameters, $validator) {
-
-            $areFiles = false;
-            if (is_array($value)) {
-                foreach ($value as $item) {
-                    $areFiles = $areFiles && ($item instanceof UploadedFile && $item->isValid());
-                }
-            }
-            return ($value instanceof UploadedFile && $value->isValid()) || $areFiles;
-        });
 
         // $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'media-manager');
          $this->loadMigrationsFrom(MANAGER_PATH.'/database/migrations');

--- a/src/Rules/FileArray.php
+++ b/src/Rules/FileArray.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Plank\MediaManager\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class FileArray implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param string $attribute
+     * @param mixed $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $areFiles = false;
+        if (is_array($value)) {
+            foreach ($value as $item) {
+                $areFiles = $areFiles && ($item instanceof UploadedFile && $item->isValid());
+            }
+        }
+        return ($value instanceof UploadedFile && $value->isValid()) || $areFiles;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'You must upload a file or collection of files.';
+    }
+}

--- a/src/Rules/FileArray.php
+++ b/src/Rules/FileArray.php
@@ -16,13 +16,14 @@ class FileArray implements Rule
      */
     public function passes($attribute, $value)
     {
-        $areFiles = false;
+        $areFiles = true;
+
         if (is_array($value)) {
             foreach ($value as $item) {
                 $areFiles = $areFiles && ($item instanceof UploadedFile && $item->isValid());
             }
         }
-        return ($value instanceof UploadedFile && $value->isValid()) || $areFiles;
+        return $areFiles;
     }
 
     /**


### PR DESCRIPTION
## Description
Closes #81

Adds new validation rule that checks uploaded files are valid
Renames file when duplicates names are detected (adds increment counter)
Adds new Request Validator for uploaded files. Allows for overrides via Service Container.

## How to test
1. Open the media manager.
2. Choose a folder
3. Upload some file
4. Upload the same file again
5. Observe that the file is named "`name`-1.jpg"
