### PR TITLE
Add backwards compatibility for mutators in media update

### DIFF
--- a/src/Http/Controllers/MediaController.php
+++ b/src/Http/Controllers/MediaController.php
@@ -157,7 +157,10 @@ class MediaController extends BaseController
 
         if (!$request->has('path')) {
             $details = $request->only(['title', 'alt', 'caption', 'credit']);
-            $media->fill($details);
+            // Can't call fill due to backwards compatibility (fill doesn't trigger mutators)... Use loop instead.
+            foreach ($details as $attribute => $detail) {
+                $media->$attribute = $detail;
+            }
         }
 
         if ($path != $media->directory) {

--- a/src/Http/Requests/MediaUpdateRequest.php
+++ b/src/Http/Requests/MediaUpdateRequest.php
@@ -24,6 +24,7 @@ class MediaUpdateRequest extends FormRequest
             'path' => ["string", "nullable"],
             'rename' => ["string", "nullable"],
             'title' => ["required_without:path", "string"],
+            'credit' => ["nullable", "string"]
         ];
     }
 


### PR DESCRIPTION
## Description
Closes #85

Swaps call to `fill()` for iterator that updates fields individually. This adds backwards compatibility with versions of laravel older than 8.X
Adds credit to update request validator.
