### PR TITLE
#103 - copy image html scroll bug

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -4189,9 +4189,13 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
     },
     copyImageHtml: function copyImageHtml(image) {
       var imageHtml = "<div><img ".concat(Object(_helpers_attributes__WEBPACK_IMPORTED_MODULE_2__["default"])(image), " /> </div>");
-      var dummyTextarea = document.createElement("textarea");
+      var dummyTextarea = document.createElement("textarea"); // add styles so the main page doesn't scroll when this is focused
+
+      dummyTextarea.style.top = "0";
+      dummyTextarea.style.left = "0";
+      dummyTextarea.style.position = "fixed";
+      document.body.append(dummyTextarea);
       dummyTextarea.innerHTML = imageHtml;
-      document.body.appendChild(dummyTextarea);
       dummyTextarea.select();
       dummyTextarea.focus();
 

--- a/resources/js/components/slidepanel/mm-slidepanel.vue
+++ b/resources/js/components/slidepanel/mm-slidepanel.vue
@@ -196,9 +196,16 @@ export default {
     },
     copyImageHtml: function(image) {
       let imageHtml = `<div><img ${getAttributes(image)} /> </div>`;
+
       let dummyTextarea = document.createElement( "textarea" );
+
+      // add styles so the main page doesn't scroll when this is focused
+      dummyTextarea.style.top = "0";
+      dummyTextarea.style.left = "0";
+      dummyTextarea.style.position = "fixed";
+
+      document.body.append(dummyTextarea);
       dummyTextarea.innerHTML = imageHtml;
-      document.body.appendChild( dummyTextarea );
       dummyTextarea.select();
       dummyTextarea.focus();
 


### PR DESCRIPTION
[Forecast](https://app.forecast.it/T7240)
[Staging](https://tce.7.plankdesign.com/admin)

**The bug**
This is a minor bug where when editing an Article if one selects an image to include in an article and clicks "Copy HTML" they are sent to the bottom of the page, as if they scrolled all the way down. 

**The fix**
The way to add text to the clipboard involves creating a new textarea tag with javascript, append it to the body (the tag ends up at the bottom of the page), making the textarea's content the desired code then select it, focus it (this is why it was scrolling) then doing the "copy".
I made the textarea position: 'fixed' so that the element is floating and won't force the page to scroll when it is focused/selected.

