### PR TITLE
99 item translations not loading after language switch

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2713,15 +2713,16 @@ __webpack_require__.r(__webpack_exports__);
 
 /* harmony default export */ __webpack_exports__["default"] = ({
   name: "mmcard",
-  props: ["item"],
+  props: ["item", "index"],
   data: function data() {
     return {
-      isSelected: false
+      isSelected: false,
+      mediaItem: this.item
     };
   },
   methods: {
-    openSelectedMedia: function openSelectedMedia(item) {
-      _event_bus_js__WEBPACK_IMPORTED_MODULE_0__["EventBus"].$emit("open-slide-panel", item);
+    openSelectedMedia: function openSelectedMedia() {
+      _event_bus_js__WEBPACK_IMPORTED_MODULE_0__["EventBus"].$emit("open-slide-panel", this.index);
     },
     pushSelected: function pushSelected(value) {
       this.current = value.id;
@@ -3005,8 +3006,15 @@ __webpack_require__.r(__webpack_exports__);
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _event_bus_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ../event-bus.js */ "./resources/js/event-bus.js");
-/* harmony import */ var _mm_card__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./mm-card */ "./resources/js/components/mm-card.vue");
+/* harmony import */ var vuex__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! vuex */ "./node_modules/vuex/dist/vuex.esm.js");
+/* harmony import */ var _event_bus_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../event-bus.js */ "./resources/js/event-bus.js");
+/* harmony import */ var _mm_card__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./mm-card */ "./resources/js/components/mm-card.vue");
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 //
 //
 //
@@ -3035,12 +3043,13 @@ __webpack_require__.r(__webpack_exports__);
 //
 //
 //
+
 
 
 /* harmony default export */ __webpack_exports__["default"] = ({
   name: "mmresults",
   components: {
-    mmcard: _mm_card__WEBPACK_IMPORTED_MODULE_1__["default"]
+    mmcard: _mm_card__WEBPACK_IMPORTED_MODULE_2__["default"]
   },
   data: function data() {
     return {
@@ -3069,15 +3078,11 @@ __webpack_require__.r(__webpack_exports__);
       if (JSON.stringify(event.option.slug) === '"delete"') {
         this.$store.dispatch("openModalDelete");
       } else if (JSON.stringify(event.option.slug) === '"details"') {
-        _event_bus_js__WEBPACK_IMPORTED_MODULE_0__["EventBus"].$emit("open-slide-panel", [event.item]);
+        _event_bus_js__WEBPACK_IMPORTED_MODULE_1__["EventBus"].$emit("open-slide-panel", [event.item]);
       }
     }
   },
-  computed: {
-    getMedia: function getMedia() {
-      return this.$store.state.mediaCollection;
-    }
-  }
+  computed: _objectSpread({}, Object(vuex__WEBPACK_IMPORTED_MODULE_0__["mapGetters"])(['getMediaArray']))
 });
 
 /***/ }),
@@ -3987,6 +3992,10 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _event_bus_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ../../event-bus.js */ "./resources/js/event-bus.js");
 /* harmony import */ var _helpers_filter_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../../helpers/filter.js */ "./resources/js/helpers/filter.js");
 /* harmony import */ var _helpers_attributes__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../../helpers/attributes */ "./resources/js/helpers/attributes.js");
+function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
+
+function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
+
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
@@ -4149,6 +4158,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
     return {
       slideOpen: false,
       langSwitch: "",
+      index: null,
       data: [],
       disk: "",
       id: "",
@@ -4229,29 +4239,64 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
     },
     capitalize: function capitalize(string) {
       return string.charAt(0).toUpperCase() + string.slice(1);
+    },
+    loadImageData: function loadImageData() {
+      //pull the media from the index of global state mediaCollection
+      var mediaItem = this.$store.state.mediaCollection[this.index];
+
+      if (!mediaItem) {
+        this.slideOpen = false;
+        return;
+      } // reorganize the media item into an object based on the translations
+      // makes it easier to switch between languages
+
+
+      var mediaByLanguage = {
+        en: _objectSpread({}, mediaItem),
+        fr: _objectSpread({}, mediaItem)
+      }; // loop over the translations for the media item, populating the above object. 
+
+      var mediaTranslations = mediaItem.translations; // in testing, some media didn't have translations
+      // in that case, the object is populated with the non-translation specific data
+      // submitting changes to the media will update the object on the DB and populate its translations array
+
+      if (mediaTranslations && mediaTranslations.length > 0) {
+        mediaTranslations.forEach(function (translation) {
+          // the media data has an id
+          // and each translation has its own id
+          // I am removing the translation's id here so it doesn't overwrite the media data's id
+          // the media's id is necessary for updating the object
+          var id = translation.id,
+              restOfTranslation = _objectWithoutProperties(translation, ["id"]); // rebuild each language's object to contain all fields 
+          // even non-language specific fields 
+          // use the language "locale" as the key to populate the mediaByLanguage object
+
+
+          mediaByLanguage[translation.locale] = _objectSpread(_objectSpread({}, mediaByLanguage[translation.locale]), restOfTranslation);
+        });
+      } // every time we switch language, it will check with the global state and make sure 
+
+
+      var dataWithCorrectTranslation = mediaByLanguage[this.langSwitch];
+      this.data = dataWithCorrectTranslation;
+      this.disk = this.data.disk;
+      this.id = this.data.id;
+      this.alt = this.data.alt;
+      this.title = this.data.title;
+      this.credit = this.data.credit;
+      this.caption = this.data.caption;
+      this.isNewMedia = this.data.isNewMedia ? true : false;
     }
   },
   mounted: function mounted() {
     var _this = this;
 
-    _event_bus_js__WEBPACK_IMPORTED_MODULE_0__["EventBus"].$on("open-slide-panel", function (value) {
-      var findCorrectTranslation = value.translations.find(function (translation) {
-        return translation.locale === _this.getSelectedLang;
-      }); // the translation sometimes has an id as well, so need to make sure that the value's id is used here, not the translation's id.
-
-      var dataWithCorrectTranslation = _objectSpread(_objectSpread(_objectSpread({}, value), findCorrectTranslation), {}, {
-        id: value.id
-      });
-
+    _event_bus_js__WEBPACK_IMPORTED_MODULE_0__["EventBus"].$on("open-slide-panel", function (index) {
+      if (!index) return;
       _this.slideOpen = true;
-      _this.data = dataWithCorrectTranslation;
-      _this.disk = _this.data.disk;
-      _this.id = _this.data.id;
-      _this.alt = _this.data.alt;
-      _this.title = _this.data.title;
-      _this.credit = _this.data.credit;
-      _this.caption = _this.data.caption;
-      _this.isNewMedia = _this.data.isNewMedia ? true : false;
+      _this.index = index;
+
+      _this.loadImageData();
     });
     _event_bus_js__WEBPACK_IMPORTED_MODULE_0__["EventBus"].$on("close-slide-panel", function () {
       _this.slideOpen = false;
@@ -4267,40 +4312,15 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
     this.langSwitch = this.$store.state.lang;
   },
   watch: {
-    getSelectedTranslation: function getSelectedTranslation() {
-      var _this$data,
-          _this2 = this;
-
-      if (!this.data || this.data.length >= 0) return;
-      var findCorrectTranslation = (_this$data = this.data) === null || _this$data === void 0 ? void 0 : _this$data.translations.find(function (translation) {
-        return translation.locale === _this2.langSwitch;
-      }); // the translation sometimes has an id as well, so need to make sure that the value's id is used here, not the translation's id.
-
-      var dataWithCorrectTranslation = _objectSpread(_objectSpread(_objectSpread({}, this.data), findCorrectTranslation), {}, {
-        id: this.data.id
-      });
-
-      this.data = dataWithCorrectTranslation;
-      this.disk = this.data.disk;
-      this.id = this.data.id;
-      this.alt = this.data.alt;
-      this.title = this.data.title;
-      this.credit = this.data.credit;
-      this.caption = this.data.caption;
-      this.isNewMedia = this.data.isNewMedia ? true : false;
-    },
     getSelectedLang: function getSelectedLang(newLang, oldLang) {
-      this.$store.dispatch("getTranslatedDirectory", this.id);
+      this.loadImageData();
     }
   },
   computed: {
     fileSize: function fileSize() {
-      var _this$data2;
+      var _this$data;
 
-      return Object(_helpers_filter_js__WEBPACK_IMPORTED_MODULE_1__["default"])((_this$data2 = this.data) === null || _this$data2 === void 0 ? void 0 : _this$data2.size);
-    },
-    getSelectedTranslation: function getSelectedTranslation() {
-      return this.$store.state.selectedTranslation;
+      return Object(_helpers_filter_js__WEBPACK_IMPORTED_MODULE_1__["default"])((_this$data = this.data) === null || _this$data === void 0 ? void 0 : _this$data.size);
     },
     getSelectedLang: function getSelectedLang() {
       return this.$store.state.lang;
@@ -13970,10 +13990,10 @@ var render = function() {
       class: { selected: _vm.setSelected },
       on: {
         dblclick: function($event) {
-          return _vm.openSelectedMedia(_vm.item)
+          return _vm.openSelectedMedia(_vm.mediaItem)
         },
         click: function($event) {
-          return _vm.pushSelected(_vm.item)
+          return _vm.pushSelected(_vm.mediaItem)
         }
       }
     },
@@ -13982,30 +14002,34 @@ var render = function() {
         "div",
         {
           staticClass: "mm__card-background",
-          style: _vm.setBackground(_vm.item)
+          style: _vm.setBackground(_vm.mediaItem)
         },
         [
-          _vm.item.aggregate_type === "document" ||
-          _vm.item.aggregate_type === "pdf" ||
-          _vm.item.aggregate_type === "audio" ||
-          _vm.item.aggregate_type === "video"
+          _vm.mediaItem.aggregate_type === "document" ||
+          _vm.mediaItem.aggregate_type === "pdf" ||
+          _vm.mediaItem.aggregate_type === "audio" ||
+          _vm.mediaItem.aggregate_type === "video"
             ? _c(
                 "div",
                 {
                   staticClass:
                     "mm__card-placeholder mm__card-default-placeholder"
                 },
-                [_vm._v("\n      " + _vm._s(_vm.item.extension) + "\n    ")]
+                [
+                  _vm._v(
+                    "\n      " + _vm._s(_vm.mediaItem.extension) + "\n    "
+                  )
+                ]
               )
             : _vm._e()
         ]
       ),
       _vm._v(" "),
       _c("div", { staticClass: "mm__card-infos" }, [
-        _c("h6", [_vm._v(_vm._s(_vm.item.filename))]),
+        _c("h6", [_vm._v(_vm._s(_vm.mediaItem.filename))]),
         _vm._v(" "),
         _c("span", { staticClass: "type" }, [
-          _vm._v(_vm._s(_vm.item.aggregate_type))
+          _vm._v(_vm._s(_vm.mediaItem.aggregate_type))
         ])
       ])
     ]
@@ -14248,7 +14272,7 @@ var render = function() {
         "div",
         { staticClass: "mm__results-grid" },
         [
-          _vm._l(_vm.getMedia, function(item) {
+          _vm._l(_vm.getMediaArray, function(item, index) {
             return _c(
               "div",
               {
@@ -14264,14 +14288,18 @@ var render = function() {
               },
               [
                 _c("mmcard", {
-                  attrs: { "data-type": item.aggregate_type, item: item }
+                  attrs: {
+                    "data-type": item.aggregate_type,
+                    item: item,
+                    index: index
+                  }
                 })
               ],
               1
             )
           }),
           _vm._v(" "),
-          _vm.getMedia.length == 0 && this.$store.state.hideDirectory
+          _vm.getMediaArray.length == 0 && this.$store.state.hideDirectory
             ? _c("div", { staticClass: "mm__search-no-result" }, [
                 _c("h3", [_vm._v(_vm._s(_vm.$t("search.no_result")))])
               ])
@@ -39365,6 +39393,9 @@ var getters = {
   },
   getMoveDirectory: function getMoveDirectory(state) {
     return state.moveDirectoryCollection;
+  },
+  getMediaArray: function getMediaArray(state) {
+    return state.mediaCollection;
   }
 };
 
@@ -39380,6 +39411,12 @@ var getters = {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "mutations", function() { return mutations; });
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 var mutations = {
   CLOSE_MODAL: function CLOSE_MODAL(state) {
     state.modalState.create = false;
@@ -39454,15 +39491,11 @@ var mutations = {
     }
   },
   UPDATE_MEDIA_VALUE: function UPDATE_MEDIA_VALUE(state, _ref) {
-    var id = _ref.id,
-        value = _ref.value;
-    var mediaElement = state.mediaCollection.find(function (q) {
+    var value = _ref.value;
+    var mediaIndex = state.mediaCollection.findIndex(function (q) {
       return q.id === value.id;
     });
-    mediaElement.credit = value.credit;
-    mediaElement.title = value.title;
-    mediaElement.alt = value.alt;
-    mediaElement.caption = value.caption;
+    state.mediaCollection[mediaIndex] = _objectSpread({}, value);
   },
   SET_MEDIATYPES: function SET_MEDIATYPES(state, items) {
     var _this = this;

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=cacd19fce1bda1bfc265",
+    "/app.js": "/app.js?id=9946500f281110417323",
     "/app.css": "/app.css?id=326aa7d4c4113ad068fe",
     "/images/icon-add.svg": "/images/icon-add.svg?id=f35ff7376a119c2d780b",
     "/images/icon-arrow-back.svg": "/images/icon-arrow-back.svg?id=963a92661eaa72c7bfd3",

--- a/resources/js/components/mm-card.vue
+++ b/resources/js/components/mm-card.vue
@@ -2,25 +2,25 @@
   <div
     class="mm__card"
     v-bind:class="{ selected: setSelected }"
-    v-on:dblclick="openSelectedMedia(item)"
-    v-on:click="pushSelected(item)"
+    v-on:dblclick="openSelectedMedia(mediaItem)"
+    v-on:click="pushSelected(mediaItem)"
   >
-    <div class="mm__card-background" :style="setBackground(item)">
+    <div class="mm__card-background" :style="setBackground(mediaItem)">
       <div
         class="mm__card-placeholder mm__card-default-placeholder"
         v-if="
-          item.aggregate_type === 'document' ||
-          item.aggregate_type === 'pdf' ||
-          item.aggregate_type === 'audio' ||
-          item.aggregate_type === 'video'
+        mediaItem.aggregate_type === 'document' ||
+        mediaItem.aggregate_type === 'pdf' ||
+        mediaItem.aggregate_type === 'audio' ||
+        mediaItem.aggregate_type === 'video'
         "
       >
-        {{ item.extension }}
+        {{ mediaItem.extension }}
       </div>
     </div>
     <div class="mm__card-infos">
-      <h6>{{ item.filename }}</h6>
-      <span class="type">{{ item.aggregate_type }}</span>
+      <h6>{{ mediaItem.filename }}</h6>
+      <span class="type">{{ mediaItem.aggregate_type }}</span>
     </div>
   </div>
 </template>
@@ -29,15 +29,16 @@
 import { EventBus } from "../event-bus.js";
 export default {
   name: "mmcard",
-  props: ["item"],
+  props: ["item", "index"],
   data() {
     return {
       isSelected: false,
+      mediaItem: this.item
     };
   },
   methods: {
-    openSelectedMedia: function (item) {
-        EventBus.$emit("open-slide-panel", item);
+    openSelectedMedia: function () {
+      EventBus.$emit("open-slide-panel", this.index);
     },
     pushSelected: function (value) {
       this.current = value.id;

--- a/resources/js/components/mm-results.vue
+++ b/resources/js/components/mm-results.vue
@@ -2,16 +2,16 @@
   <div class="mm__results">
     <div class="mm__results-grid">
       <div
-        v-for="item in getMedia"
+        v-for="item, index in getMediaArray"
         :key="item.id"
         class="mm__results-single"
         @contextmenu.prevent.stop="handleClick($event, item)"
       >
-        <mmcard :data-type="item.aggregate_type" :item="item"></mmcard>
+        <mmcard :data-type="item.aggregate_type" :item="item" :index="index"></mmcard>
       </div>
       <div
         class="mm__search-no-result"
-        v-if="getMedia.length == 0 && this.$store.state.hideDirectory"
+        v-if="getMediaArray.length == 0 && this.$store.state.hideDirectory"
       >
         <h3>{{ $t("search.no_result") }}</h3>
       </div>
@@ -27,6 +27,7 @@
 </template>
 
 <script>
+import { mapGetters } from "vuex";
 import { EventBus } from "../event-bus.js";
 import mmcard from "./mm-card";
 
@@ -70,10 +71,7 @@ export default {
     },
   },
   computed: {
-    getMedia() {
-      return this.$store.state.mediaCollection;
-    },
-
+    ...mapGetters(['getMediaArray']),
   },
 };
 </script>

--- a/resources/js/components/slidepanel/mm-slidepanel.vue
+++ b/resources/js/components/slidepanel/mm-slidepanel.vue
@@ -156,6 +156,7 @@ export default {
     return {
       slideOpen: false,
       langSwitch: "",
+      index: null,
       data: [],
       disk: "",
       id: "",
@@ -189,6 +190,7 @@ export default {
         caption: this.caption,
         isNewMedia: this.isNewMedia
       });
+      
     },
     selectFile: function () {
         handleContent(this.$store.state.selectedElem);
@@ -232,16 +234,43 @@ export default {
     capitalize(string) {
       return string.charAt(0).toUpperCase() + string.slice(1);
     },
-  },
-	mounted() {
-		EventBus.$on("open-slide-panel", (value) => {
-			const findCorrectTranslation = value.translations.find((translation) => {
-				return translation.locale === this.getSelectedLang
-			})
-			// the translation sometimes has an id as well, so need to make sure that the value's id is used here, not the translation's id.
-			const dataWithCorrectTranslation = { ...value, ...findCorrectTranslation, id: value.id }
+    loadImageData() {
+      //pull the media from the index of global state mediaCollection
+      let mediaItem = this.$store.state.mediaCollection[this.index]
 
-			this.slideOpen = true
+      if (!mediaItem) {
+        this.slideOpen = false;
+        return;
+      }
+      // reorganize the media item into an object based on the translations
+      // makes it easier to switch between languages
+      let mediaByLanguage = {
+        en: {...mediaItem}, 
+        fr: {...mediaItem}
+      };
+      // loop over the translations for the media item, populating the above object. 
+      const mediaTranslations = mediaItem.translations;
+      
+      // in testing, some media didn't have translations
+      // in that case, the object is populated with the non-translation specific data
+      // submitting changes to the media will update the object on the DB and populate its translations array
+      if (mediaTranslations && mediaTranslations.length > 0) {
+
+        mediaTranslations.forEach((translation) => {
+          // the media data has an id
+          // and each translation has its own id
+          // I am removing the translation's id here so it doesn't overwrite the media data's id
+          // the media's id is necessary for updating the object
+          const {id, ...restOfTranslation} = translation;
+          // rebuild each language's object to contain all fields 
+          // even non-language specific fields 
+          // use the language "locale" as the key to populate the mediaByLanguage object
+          mediaByLanguage[translation.locale] = {...mediaByLanguage[translation.locale], ...restOfTranslation};
+        })
+      }
+      // every time we switch language, it will check with the global state and make sure 
+      const dataWithCorrectTranslation = mediaByLanguage[this.langSwitch];
+
 			this.data = dataWithCorrectTranslation
 			this.disk = this.data.disk
 			this.id = this.data.id
@@ -250,6 +279,16 @@ export default {
 			this.credit = this.data.credit
 			this.caption = this.data.caption
 			this.isNewMedia = this.data.isNewMedia ? true : false
+    }
+  },
+	mounted() {
+		EventBus.$on("open-slide-panel", (index) => {
+      if (!index) return;
+
+      this.slideOpen = true
+      this.index = index
+      
+      this.loadImageData()
 		})
 		EventBus.$on("close-slide-panel", () => {
 			this.slideOpen = false
@@ -266,34 +305,14 @@ export default {
 		this.langSwitch = this.$store.state.lang
 	},
 	watch: {
-		getSelectedTranslation() {
-			if (!this.data || this.data.length >= 0) return
-			const findCorrectTranslation = this.data?.translations.find((translation) => {
-				return translation.locale === this.langSwitch
-			})
-			// the translation sometimes has an id as well, so need to make sure that the value's id is used here, not the translation's id.
-			const dataWithCorrectTranslation = { ...this.data, ...findCorrectTranslation, id: this.data.id }
-
-			this.data = dataWithCorrectTranslation
-			this.disk = this.data.disk
-			this.id = this.data.id
-			this.alt = this.data.alt
-			this.title = this.data.title
-			this.credit = this.data.credit
-			this.caption = this.data.caption
-			this.isNewMedia = this.data.isNewMedia ? true : false
-		},
 		getSelectedLang(newLang, oldLang) {
-			this.$store.dispatch("getTranslatedDirectory", this.id)
+      this.loadImageData();
 		},
 	},
 	computed: {
 		fileSize() {
 			return fileSizeFilter(this.data?.size)
 		},
-    getSelectedTranslation() {
-      return this.$store.state.selectedTranslation;
-    },
     getSelectedLang() {
       return this.$store.state.lang;
     },

--- a/resources/js/components/slidepanel/mm-slidepanel.vue
+++ b/resources/js/components/slidepanel/mm-slidepanel.vue
@@ -235,11 +235,11 @@ export default {
       return string.charAt(0).toUpperCase() + string.slice(1);
     },
     loadImageData() {
-      //pull the media from the index of global state mediaCollection
+      //pull the media based on the index of global state mediaCollection
       let mediaItem = this.$store.state.mediaCollection[this.index]
 
       if (!mediaItem) {
-        this.slideOpen = false;
+        this.close();
         return;
       }
       // reorganize the media item into an object based on the translations
@@ -283,7 +283,10 @@ export default {
   },
 	mounted() {
 		EventBus.$on("open-slide-panel", (index) => {
-      if (!index) return;
+      if (!index) {
+        this.close()
+        return
+      };
 
       this.slideOpen = true
       this.index = index
@@ -305,7 +308,7 @@ export default {
 		this.langSwitch = this.$store.state.lang
 	},
 	watch: {
-		getSelectedLang(newLang, oldLang) {
+		getSelectedLang() {
       this.loadImageData();
 		},
 	},

--- a/resources/js/store/getters.js
+++ b/resources/js/store/getters.js
@@ -7,5 +7,8 @@ export const getters = {
   },
   getMoveDirectory: state => {
     return state.moveDirectoryCollection;
-  }
+  },
+  getMediaArray: state => {
+    return state.mediaCollection;
+  },
 };

--- a/resources/js/store/mutations.js
+++ b/resources/js/store/mutations.js
@@ -66,12 +66,9 @@ export const mutations = {
       state.allMediaLoaded = false;
     }
   },
-  UPDATE_MEDIA_VALUE(state, { id, value }) {
-    const mediaElement = state.mediaCollection.find(q => q.id === value.id);
-    mediaElement.credit = value.credit;
-    mediaElement.title = value.title;
-    mediaElement.alt = value.alt;
-    mediaElement.caption = value.caption;
+  UPDATE_MEDIA_VALUE(state, { value }) {
+    const mediaIndex = state.mediaCollection.findIndex(q => q.id === value.id);
+    state.mediaCollection[mediaIndex] = {...value};
   },
   SET_MEDIATYPES(state, items) {
     for (let i = 0; i < items.length; i++) {


### PR DESCRIPTION
[Forecast](https://app.forecast.it/T7931)
[Staging](https://tce.7.plankdesign.com/admin)

**The bug** 
Media manager
- double click an image to open the sidepanel
-  update a value in english and then save
- toggle to french
- toggle back to english
- The value shown will be the original data from page load.
- if you refresh the page, the update will display.

**What was done**

When updating a value on media in the slide-panel, the vuex mediaCollection array was getting updated
Slide-panel was relying on a prop passed through the Eventbus to populate the media details (from the `mm-card` component). These props were not updating when the object inside the global mediaCollection array was being updated.

I reconfigured how the slidePanel displays its data. I pass a prop of the index of the item in the mediaCollection array. 

When data is updated on the slidepanel, the object in the mediaCollection array is updated and the slidepanel reloads its data. 

I reorganized how the slidePanel handles the media data. 
The media data has some fields that exist in the root level of data, then the title, caption, etc. live in an array `translations`.
To make it easier to switch between languages, I take the non-language specific data and insert it into both values of an object broken down by language: 
```
{ 
    en: { all media data and english specific data }, 
    fr: { all media data and french specific data} 
} 
```


Each translation holds a full set of data. 

**Tested** 
- Open slide-panel
- Language: english, 
- update title
- save, wait for confirmation
- switch language to french
- switch language back to english
- The title is the updated value. 
- Close slidePanel
- Open different image
- Close that image
- Return to first image
- Title is still the updated value